### PR TITLE
Fix geometry once per workflow from migrating branch

### DIFF
--- a/src/aid2e/utilities/epic_utils/epic_stack.py
+++ b/src/aid2e/utilities/epic_utils/epic_stack.py
@@ -186,14 +186,21 @@ class EpicStack(ExperimentStack):
 
         modify_xml_files(remapped_modifications)
 
+        compile_commands = (
+            f"cmake -B {trial_geo_dir}/build -S {trial_geo_dir}\n"
+            f"-DCMAKE_INSTALL_PREFIX={trial_geo_dir}/install\n"
+            f"cmake --build {trial_geo_dir}/build\n"
+            f"cmake --install {trial_geo_dir}/build\n"
+        )
+        compile_script = os.path.join(trial_geo_dir, "compile_geo.sh")
+        with open(compile_script, "w") as script:
+            script.writelines(compile_commands)
+        os.chmod(compile_script, 0o777)
+
         compiled_log = os.path.join(trial_geo_dir, "compiled.log")
+        do_compiling = self.make_driver_command(compile_script)
         if not os.path.exists(compiled_log):
-            os.system(
-                f"cmake -B {trial_geo_dir}/build -S {trial_geo_dir} "
-                f"-DCMAKE_INSTALL_PREFIX={trial_geo_dir}/install"
-            )
-            os.system(f"cmake --build {trial_geo_dir}/build")
-            os.system(f"cmake --install {trial_geo_dir}/build")
+            os.system(f"{do_compiling}")
             with open(compiled_log, "w") as f:
                 f.write(f"Workflow {workflow_id} geometry compiled\n")
 

--- a/src/aid2e/utilities/epic_utils/epic_stack.py
+++ b/src/aid2e/utilities/epic_utils/epic_stack.py
@@ -148,51 +148,75 @@ class EpicStack(ExperimentStack):
     rec: EpicRecLayer = field(default_factory = EpicRecLayer)
     ana: EpicAnaLayer = field(default_factory = EpicAnaLayer)
 
-    def prepare_for_execution(self, **kwargs) -> Optional[str]:
+    def prepare_workflow_geometry(
+        self,
+        workflow_dir: str,
+        design_point: Dict[str, Any],
+        problem_config: Any,
+        workflow_id: str,
+    ) -> str:
         """
-        Prepare for running ePIC driver script.
+        Prepare geometry once for the whole workflow/design point.
+        Returns the prepared geometry directory.
         """
-        context = None
-        for arg, value in kwargs.items():
-            if isinstance(value, JobContext):
-                context = value
-
-        # JobContext must be provided to access execution dir
-        if context is None:
-            raise RuntimeError("No JobContext provided to EpicStack.prepare_for_execution")
-
-        # Need EpicDesignConfig to determine geometry modifications
-        if context.problem_config.design_config is None:
-            raise AttributeError("DesignConfig not present in job context.")
-        if not isinstance(context.problem_config.design_config, EpicDesignConfig):
+        if problem_config is None or problem_config.design_config is None:
+            raise AttributeError("DesignConfig not present in workflow context.")
+        if not isinstance(problem_config.design_config, EpicDesignConfig):
             raise TypeError("DesignConfig is not an instance of EpicDesignConfig.")
-        design = context.problem_config.design_config
 
-        # make sure a geometry directory has been defined as a template
         if 'EPIC_INSTALL' not in os.environ:
             raise EnvironmentError("Variable 'EPIC_INSTALL' not set. Must define epic_install.")
 
+        design = problem_config.design_config
         template_geo_dir = os.environ['EPIC_INSTALL']
-        trial_geo_dir = '/'.join([context.execution_dir, os.path.basename(template_geo_dir)])
+        trial_geo_dir = os.path.join(workflow_dir, os.path.basename(template_geo_dir))
+
         if not os.path.exists(trial_geo_dir):
             shutil.copytree(template_geo_dir, trial_geo_dir)
 
-        modifications = design.get_xml_modifications(context.design_point)
-        modify_xml_files(modifications)
-        context.add_log(f"Modified geometry in job {context.job_id}")
+        original_modifications = design.get_xml_modifications(design_point)
 
-        # list of commands to execute at start of driver script
-        commands = "\n".join([
-            "set -e\n",
-            f"if [ ! -f {trial_geo_dir}/compiled.log ]; then",
-            f"  cmake -B {trial_geo_dir}/build -S {trial_geo_dir} -DCMAKE_INSTALL_PREFIX={trial_geo_dir}/install",
-            f"  cmake --build {trial_geo_dir}/build",
-            f"  cmake --install {trial_geo_dir}/build\n",
-            "  time=$(date -u)",
-            f'  echo "Job {context.job_id} ' + 'geometry compiled at ${time}" > ' + f"{trial_geo_dir}/compiled.log",
-            "fi",
-        ])
-        return commands
+        remapped_modifications = {}
+        for src_file, params in original_modifications.items():
+            if src_file.startswith(template_geo_dir):
+                dst_file = src_file.replace(template_geo_dir, trial_geo_dir, 1)
+            else:
+                dst_file = src_file
+            remapped_modifications[dst_file] = params
+
+        modify_xml_files(remapped_modifications)
+
+        compiled_log = os.path.join(trial_geo_dir, "compiled.log")
+        if not os.path.exists(compiled_log):
+            os.system(
+                f"cmake -B {trial_geo_dir}/build -S {trial_geo_dir} "
+                f"-DCMAKE_INSTALL_PREFIX={trial_geo_dir}/install"
+            )
+            os.system(f"cmake --build {trial_geo_dir}/build")
+            os.system(f"cmake --install {trial_geo_dir}/build")
+            with open(compiled_log, "w") as f:
+                f.write(f"Workflow {workflow_id} geometry compiled\n")
+
+        return trial_geo_dir
+
+    def prepare_for_execution(self, **kwargs) -> Optional[str]:
+        context = None
+        for _, value in kwargs.items():
+            if isinstance(value, JobContext):
+                context = value
+
+        if context is None:
+            raise RuntimeError("No JobContext provided to EpicStack.prepare_for_execution")
+
+        if context.workflow_context is None:
+            raise RuntimeError("No workflow context provided to EpicStack.prepare_for_execution")
+
+        trial_geo_dir = context.workflow_context.parameters.get("prepared_geometry_dir")
+        if not trial_geo_dir:
+            raise RuntimeError("No prepared geometry directory found in workflow context")
+
+        context.add_log(f"Using pre-built geometry from {trial_geo_dir}")
+        return None
 
     def make_driver_script(
         self,
@@ -221,8 +245,14 @@ class EpicStack(ExperimentStack):
         # reconstruct geometry dir for job
         #   - FIXME this can be improved! We can likely make use
         #     of xcom to retrieve this
-        template_geo_dir = os.environ['EPIC_INSTALL']
-        trial_geo_dir = '/'.join([context.execution_dir, os.path.basename(template_geo_dir)])
+
+        # template_geo_dir = os.environ['EPIC_INSTALL']
+        # trial_geo_dir = '/'.join([context.execution_dir, os.path.basename(template_geo_dir)])
+        if context.workflow_context is None:
+            raise RuntimeError("No workflow context provided to EpicStack.make_driver_script")
+        trial_geo_dir = context.workflow_context.parameters.get("prepared_geometry_dir")
+        if not trial_geo_dir:
+            raise RuntimeError("No prepared geometry directory found in workflow context")
 
         # make sure a geometry config has been specififed
         if 'EPIC_CONFIG' not in os.environ:

--- a/src/aid2e/utilities/workflows/dag_executor.py
+++ b/src/aid2e/utilities/workflows/dag_executor.py
@@ -62,6 +62,7 @@ from .execution_engine import (
     WorkflowSharedContext,
 )
 from .execution_logger import ExecutionLogger
+from aid2e.utilities.configurations.stack_registry import StackRegistry
 
 class DAGExecutor:
     """Executor for DAG-based workflow orchestration.
@@ -213,9 +214,13 @@ class DAGExecutor:
         self.workflow_context = WorkflowSharedContext()
 
         try:
-            if self.problem_config is not None and self.problem_config.design_config is not None:
-                from aid2e.utilities.epic_utils.epic_stack import EpicStack
-                stack = EpicStack()
+            if (
+                self.problem_config is not None
+                and self.problem_config.design_config is not None
+                and self.workflow.stack_type is not None
+            ):
+                stack_class = StackRegistry.get_experimental_stack(self.workflow.stack_type)
+                stack = stack_class()
                 prepared_geometry_dir = stack.prepare_workflow_geometry(
                     workflow_dir=str(self.output_dir),
                     design_point=design_point,

--- a/src/aid2e/utilities/workflows/dag_executor.py
+++ b/src/aid2e/utilities/workflows/dag_executor.py
@@ -229,6 +229,14 @@ class DAGExecutor:
                 self._execute_branch(branch, design_point)
 
             objectives = self._compute_objectives()
+
+            self.logger.checkpoint(
+                "workflow_complete",
+                "success",
+                f"Workflow execution completed. Objectives: {objectives}",
+                context={"objectives": objectives},
+            )
+
             return objectives
             
         except Exception as e:

--- a/src/aid2e/utilities/workflows/dag_executor.py
+++ b/src/aid2e/utilities/workflows/dag_executor.py
@@ -63,9 +63,6 @@ from .execution_engine import (
 )
 from .execution_logger import ExecutionLogger
 
-from aid2e.utilities.epic_utils.epic_stack import EpicStack
-
-
 class DAGExecutor:
     """Executor for DAG-based workflow orchestration.
     
@@ -199,6 +196,7 @@ class DAGExecutor:
 
         try:
             if self.problem_config is not None and self.problem_config.design_config is not None:
+                from aid2e.utilities.epic_utils.epic_stack import EpicStack
                 stack = EpicStack()
                 prepared_geometry_dir = stack.prepare_workflow_geometry(
                     workflow_dir=str(self.output_dir),

--- a/src/aid2e/utilities/workflows/dag_executor.py
+++ b/src/aid2e/utilities/workflows/dag_executor.py
@@ -98,7 +98,7 @@ class DAGExecutor:
         workflow: WorkflowDefinition,
         base_output_dir: str = "/tmp/aid2e_runs",
         log_level: str = "INFO",
-        problem_config: Optional[ProblemConfig] = None,
+        problem_config: Optional[ProblemConfiguration] = None,
         scheduler_config: Optional[Dict[str, Any]] = None,
     ):
         """Initialize DAG Executor.

--- a/src/aid2e/utilities/workflows/dag_executor.py
+++ b/src/aid2e/utilities/workflows/dag_executor.py
@@ -183,7 +183,25 @@ class DAGExecutor:
             raise ValueError(f"Scheduler {runner_type} not available: {e}") from e
         
     def execute(self, design_point: Dict[str, Any]) -> Dict[str, float]:
-        """Execute workflow for a given design point."""
+        """Execute workflow for a given design point.
+        
+        This is the main entry point for workflow execution. It orchestrates
+        the entire workflow from start to finish and returns computed objectives.
+
+        Args:
+            design_point: Design point parameters (e.g., {"x1": 0.5, "x2": 0.7}).
+            
+        Returns:
+            objectives: Computed objectives as {objective_name: value}.
+            
+        Raises:
+            ValueError: If workflow is invalid or execution fails.
+            
+        Example:
+            >>> design_point = {"x1": 0.5, "x2": 0.7, "x3": 0.3}
+            >>> objectives = executor.execute(design_point)
+            >>> print(objectives)  # {"f1": 0.234, "f2": 0.876}
+        """
 
         self.logger.checkpoint(
             "workflow_start",

--- a/src/aid2e/utilities/workflows/dag_executor.py
+++ b/src/aid2e/utilities/workflows/dag_executor.py
@@ -59,8 +59,11 @@ from .execution_engine import (
     JobContext,
     StageContext,
     BranchContext,
+    WorkflowSharedContext,
 )
 from .execution_logger import ExecutionLogger
+
+from aid2e.utilities.epic_utils.epic_stack import EpicStack
 
 
 class DAGExecutor:
@@ -181,49 +184,35 @@ class DAGExecutor:
                 f"Make sure the scheduler module is installed."
             )
             raise ValueError(f"Scheduler {runner_type} not available: {e}") from e
-    
+        
     def execute(self, design_point: Dict[str, Any]) -> Dict[str, float]:
-        """Execute workflow for a given design point.
-        
-        This is the main entry point for workflow execution. It orchestrates
-        the entire workflow from start to finish and returns computed objectives.
-        
-        Args:
-            design_point: Design point parameters (e.g., {"x1": 0.5, "x2": 0.7}).
-            
-        Returns:
-            objectives: Computed objectives as {objective_name: value}.
-            
-        Raises:
-            ValueError: If workflow is invalid or execution fails.
-            
-        Example:
-            >>> design_point = {"x1": 0.5, "x2": 0.7, "x3": 0.3}
-            >>> objectives = executor.execute(design_point)
-            >>> print(objectives)  # {"f1": 0.234, "f2": 0.876}
-        """
+        """Execute workflow for a given design point."""
+
         self.logger.checkpoint(
             "workflow_start",
             "start",
             f"Starting workflow execution for design point: {design_point}",
             context={"design_point": design_point},
         )
-        
+
+        self.workflow_context = WorkflowSharedContext()
+
         try:
-            # Execute all branches in the workflow
+            if self.problem_config is not None and self.problem_config.design_config is not None:
+                stack = EpicStack()
+                prepared_geometry_dir = stack.prepare_workflow_geometry(
+                    workflow_dir=str(self.output_dir),
+                    design_point=design_point,
+                    problem_config=self.problem_config,
+                    workflow_id=self.workflow.name,
+                )
+                self.workflow_context.parameters["prepared_geometry_dir"] = prepared_geometry_dir
+                self.logger.log_info(f"Prepared geometry once at: {prepared_geometry_dir}")
+
             for branch in self._get_branches():
                 self._execute_branch(branch, design_point)
-            
-            # Compute objectives from outputs
+
             objectives = self._compute_objectives()
-            
-            self.logger.checkpoint(
-                "workflow_complete",
-                "success",
-                f"Workflow execution completed. Objectives: {objectives}",
-                context={"objectives": objectives},
-            )
-            
             return objectives
             
         except Exception as e:
@@ -440,6 +429,8 @@ class DAGExecutor:
                 xcom=self.global_xcom,
                 stage_context=stage_context,
                 execution_dir=str(self.output_dir / "jobs" / job_id),
+                problem_config=self.problem_config,
+                workflow_context=self.workflow_context,
             )
             
             # Ensure job execution directory exists
@@ -679,6 +670,7 @@ class DAGExecutor:
             stage_context=stage_context,
             execution_dir=str(self.output_dir / "jobs" / job_id),
             problem_config=self.problem_config,
+            workflow_context=self.workflow_context,
         )
         
         # Ensure job execution directory exists

--- a/src/aid2e/utilities/workflows/execution_engine.py
+++ b/src/aid2e/utilities/workflows/execution_engine.py
@@ -45,6 +45,10 @@ from aid2e.utilities.configurations.stack_registry import StackRegistry
 
 from .experimental_stack import ExperimentStack
 
+@dataclass
+class WorkflowSharedContext:
+    """Context shared across all jobs of one workflow execution."""
+    parameters: Dict[str, Any] = field(default_factory=dict)
 
 @dataclass
 class BranchContext:
@@ -91,6 +95,7 @@ class JobContext:
         stage_context: Parent stage context (optional).
         problem_config: Problem configuration for accessing stack-
                         dependent design space
+        workflow_context: Shared workflow context (optional).
     """
     job_id: str
     stage_id: str
@@ -102,6 +107,7 @@ class JobContext:
     execution_dir: Optional[str] = None
     stage_context: Optional[StageContext] = None
     problem_config: Optional[ProblemConfiguration] = None
+    workflow_context: Optional[WorkflowSharedContext] = None
 
     def xcom_push(self, key: str, value: Any) -> None:
         """Push data to XCom for downstream jobs.

--- a/src/aid2e/utilities/workflows/experimental_stack.py
+++ b/src/aid2e/utilities/workflows/experimental_stack.py
@@ -272,6 +272,20 @@ class ExperimentStack(ABC):
         """
         pass
 
+    def prepare_workflow_geometry(
+        self,
+        workflow_dir: str,
+        design_point: Dict[str, Any],
+        problem_config: Any,
+        workflow_id: str,
+    ) -> str:
+        """
+        Prepare geometry for workflow/design point.
+        Returns the prepared geometry directory.
+        """
+        return workflow_dir
+
+
     def make_driver_script(
         self,
         script: str,

--- a/src/aid2e/utilities/workflows/workflow_config.py
+++ b/src/aid2e/utilities/workflows/workflow_config.py
@@ -243,6 +243,7 @@ class WorkflowDefinition(BaseModel):
     """
     name: str = Field(..., description="Workflow name")
     description: Optional[str] = Field(default=None, description="Workflow description")
+    stack_type: Optional[str] = Field(default=None,description="Experimental stack type for workflow-level geometry prep")
     branches: List[BranchDefinition] = Field(default_factory=list, description="Workflow branches (optional)")
     objectives: List[ObjectiveDefinition] = Field(
         default_factory=list,


### PR DESCRIPTION
Closes Issue #38 

Move geometry modification and compilation from per-job execution to once per workflow. Previously, geometry modification and compilation were performed for every job. This change ensures that geometry preparation is performed once per workflow (i.e. per design point), which is more efficient.

**Changes**

- Introduce a WorkflowSharedContext to share data across all jobs of a workflow
- Add EpicStack.prepare_workflow_geometry() to:
copy the geometry from EPIC_INSTALL into a workflow-local directory
apply XML modifications
build the geometry once
- Update DAGExecutor.execute() to:
prepare geometry once at workflow start (per design point)
store the prepared geometry directory in the shared workflow context
- Simplify EpicStack.prepare_for_execution() to reuse the pre-built geometry instead of rebuilding it per job
- Update make_driver_script() to use the workflow-level geometry directory
- Fix a circular import in DAGExecutor by moving the EpicStack import inside execute()

**Testing**

The following tests were run successfully:

pytest tests/test_utilities/test_epic_utils/test_epic_stack.py -q
pytest tests/test_workflows/test_dag_executor.py -q
pytest tests/test_workflows -q

Running the full test suite on migrating-configuration-models currently fails due to unrelated issues (e.g. missing ClassVar import in epic_env_config.py and AxParameterConstraint in optimizers.ax). To validate the changes, tests were executed on top of the fixes introduced in PR #39, which resolve the ClassVar issue. The geometry workflow changes were verified in that context.

**Additional**

XML modifications are now applied to the workflow-local copy of the geometry rather than the original EPIC_INSTALL directory
No changes were made to EpicDesignConfig or configuration APIs