### PR TITLE
Fix various pytest failures

### DIFF
--- a/tests/test_optimizers/test_base_optimizer_integration.py
+++ b/tests/test_optimizers/test_base_optimizer_integration.py
@@ -109,8 +109,10 @@ def test_ax_optimizer_builds_default_sobol_to_mbm_strategy():
         objective_names=["f1", "f2"],
     )
 
-    nodes = optimizer.generation_strategy.nodes
-    assert [node.name for node in nodes] == ["Sobol", "ModularBoTorch"]
+    names_and_nodes = optimizer.generation_strategy.nodes_by_name
+    names = list(names_and_nodes.keys())
+    nodes = list(names_and_nodes.values())
+    assert names == ["Sobol", "ModularBoTorch"]
     sobol_spec = nodes[0].generator_specs[0]
     model_spec = nodes[1].generator_specs[0]
 
@@ -151,7 +153,8 @@ def test_ax_optimizer_resolves_symbolic_generator_kwargs():
         objective_names=["f1", "f2"],
     )
 
-    model_spec = optimizer.generation_strategy.nodes[1].generator_specs[0]
+    nodes = list(optimizer.generation_strategy.nodes_by_name.values())
+    model_spec = nodes[1].generator_specs[0]
     assert model_spec.generator_kwargs["botorch_acqf_class"].__name__ == (
         "qLogNoisyExpectedHypervolumeImprovement"
     )
@@ -180,7 +183,7 @@ def test_ax_optimizer_supports_center_initialization():
         objective_names=["loss"],
     )
 
-    nodes = optimizer.generation_strategy.nodes
+    nodes = list(optimizer.generation_strategy.nodes_by_name.values())
     assert nodes[0].__class__.__name__ == "CenterGenerationNode"
     assert nodes[1].name == "Sobol"
     assert nodes[1].transition_criteria[0].threshold == 3
@@ -204,7 +207,8 @@ def test_ax_optimizer_supports_uniform_initialization():
         objective_names=["loss"],
     )
 
-    first_node_enum = optimizer.generation_strategy.nodes[0].generator_specs[0].generator_enum
+    nodes = list(optimizer.generation_strategy.nodes_by_name.values())
+    first_node_enum = nodes[0].generator_specs[0].generator_enum
     assert first_node_enum in {Generators.UNIFORM, Generators.SOBOL}
 
 

--- a/tests/test_schedulers/test_joblib_scheduler.py
+++ b/tests/test_schedulers/test_joblib_scheduler.py
@@ -163,10 +163,10 @@ class TestJobLibSchedulerExecution:
     def test_job_with_payload_environment(self):
         """Test job receives payload via JOB_PAYLOAD environment variable."""
         scheduler = JobLibScheduler()
-        
+
         job_def = {
             'name': 'payload_job',
-            'command': 'python -c "import os, json; print(json.dumps(json.loads(os.environ[\'JOB_PAYLOAD\'])))"',
+            'command': 'python -c "import os, json, base64, pickle; print(json.dumps(pickle.loads(base64.b64decode(os.environ[\'JOB_PAYLOAD_PICKLE\']))))"',
             'payload': {'param1': 'value1', 'param2': 42},
             'outputs': [],
         }

--- a/tests/test_utilities/test_configurations/test_config_file_loading.py
+++ b/tests/test_utilities/test_configurations/test_config_file_loading.py
@@ -82,7 +82,7 @@ def test_problem_config_loader_stack_registry(tmp_path):
     problem_payload = {
         "problem": {
             "name": "DTLZ2 Multi-Objective Optimization",
-            "type": "toy",
+            "problem_type": "toy",
             "output_location": str(output_dir),
             "work_location": str(work_dir),
             "inline_design": {
@@ -90,8 +90,8 @@ def test_problem_config_loader_stack_registry(tmp_path):
                 "parameter_constraints": design_data["design_space"].get("design_constraints", []),
             },
             "objectives": [
-                {"name": "f1", "minimize": True},
-                {"name": "f2", "minimize": True},
+                {"name": "f1", "direction": "minimize"},
+                {"name": "f2", "direction": "minimize"},
             ],
             "epic_environment": {
                 "singularity_image": "/home/eic/local/lib/eic_xl-nightly.sif",

--- a/tests/test_workflows/test_dag_executor.py
+++ b/tests/test_workflows/test_dag_executor.py
@@ -396,9 +396,14 @@ class TestEndToEndExecution:
         # Should have executed 2 jobs (from job_factory n=2)
         assert len(executor.global_xcom) >= 2
         
-        # Check output directory exists
+        # Check output directories exists
         assert executor.output_dir.exists()
-        assert (executor.output_dir / "jobs").exists()
+        assert (executor.output_dir / "evaluate").exists()
+        assert any((executor.output_dir / "evaluate").iterdir())
+
+        # Confirm that 2 job directories were created
+        job_dirs = list((executor.output_dir / "evaluate").glob("evaluate_eval_job_*"))
+        assert len(job_dirs) == 2
 
 
 # Pytest fixtures


### PR DESCRIPTION
This PR fixes a few bugs causing pytests to fail for the `optimizers`, `configurations`, `scheduler`, `workflows` modules.

### Fixes:
- [x] `GenerationStrategy._nodes` are now retrieved via `GenerationStrategy.nodes_by_names` rather than attempting to access them directly in a handful of tests in `tests/test_optimizers/test_base_optimizer_integration.py`
- [x] Legacy `ProblemConfiguration.type` and `ObjectiveConfiguration.minimize` keys have been updated to  `ProblemConfiguration.problem_type` and `ObjectiveConfiguration.direction` respectively in `tests/test_utilities/test_configurations/test_config_file_loading.py::test_problem_config_loader_stack_registry`
- [x] The test command in `tests/test_schedulers/test_joblib_scheduler.py::TestJobLibSchedulerExecution::test_job_with_payload_environment` has been updated to correctly unpickle the payload first
- [x] Outdated directory structures have been updated in  `tests/test_workflows/test_dag_executor.py::TestEndToEndExecution::test_complete_workflow_execution`, and tests have been expanded to also confirm that 2 job directories were created