### PR TITLE
Get ePIC stack example running

### DIFF
--- a/examples/epic/epic_stack_example.py
+++ b/examples/epic/epic_stack_example.py
@@ -34,6 +34,7 @@ from aid2e.utilities.workflows import (
     DAGExecutor,
     JobContext,
     modify_xml_files,
+    WorkflowSharedContext,
 )
 
 # constants
@@ -79,7 +80,7 @@ CONST = {
         "epic_environment" : {
             "epic_install" : "epic_example_test/epic",
             "epic_config"  : "epic",
-            "eic_shell"    : "/path/to/my/eic-shell",
+            "eic_shell"    : "/home/dereka/.bin/eic-shell",
         },
     },
 }
@@ -88,6 +89,7 @@ CONST = {
 # =============================================================================
 # Do template substitution
 # =============================================================================
+
 def substitute_templates(layers: List[EpicLayerConfig], context: JobContext):
     """Apply template substitutes (parallels StackExecutionEngie._apply_template_substitution)"""
 
@@ -150,6 +152,7 @@ def setup():
 # =============================================================================
 # Example 0: Modify ePIC geometry
 # =============================================================================
+
 def example_modify_geometry():
     """Modify ePIC geometry"""
 
@@ -183,7 +186,7 @@ def example_configure_layers():
     #       during execution
     cfg_geo = EpicLayerConfig(
         name = "geo",
-        inputs = ["{{context.execution_dir}}/epic/install/share/epic/epic.xml"],
+        inputs = ["{{context.geometry_dir}}/install/share/epic/epic.xml"],
         outputs = ["{{context.execution_dir}}/epic_geo.overlaps.txt"],
     )
     cfg_sim_A = EpicLayerConfig(
@@ -236,6 +239,7 @@ def example_configure_layers():
 # =============================================================================
 # Example 2: Instantiate Configurations and Context
 # =============================================================================
+
 def example_make_configs_and_context():
 
     design = EpicDesignConfig(**CONST['design'])
@@ -271,6 +275,7 @@ def example_make_configs_and_context():
         logs = [f"{CONST['test_dir']}/make_test_driver.log"],
         execution_dir =  f"{CONST['test_dir']}",
         problem_config = problem,
+        workflow_context = WorkflowSharedContext(),
     )
 
     print(f"  -- Created JobContext:\n    context = {context}")
@@ -287,6 +292,10 @@ def example_generate_driver(layers: List[EpicLayerConfig], configs: Tuple[Proble
     # grab context and instantiate an ePIC stack
     context = configs[1]
     epic_stack = EpicStack()
+
+    # add a dummy prepared geometry directory
+    # to workflow_context for testing
+    context.workflow_context.parameters["prepared_geometry_dir"] = CONST["enviro"]["epic_environment"]["epic_install"]
 
     # make sure necessary environment variables are set
     context.problem_config.environment_config.activate()
@@ -423,6 +432,7 @@ def example_run_script(layers: List[EpicLayerConfig], configs: Tuple[ProblemConf
         description = "An ePIC pipeline: check geometry → run simulations → run reco + ana",
         branches = [branch],
         objectives = [],
+        stack_type = 'epic',
     )
     print(f"  -- Defined workflow:\n    {branch}\n    {workflow}")
 

--- a/examples/epic/epic_stack_example.py
+++ b/examples/epic/epic_stack_example.py
@@ -97,6 +97,8 @@ def substitute_templates(layers: List[EpicLayerConfig], context: JobContext):
         result = text
         result = result.replace("{{context.job_id}}", str(context.job_id))
         result = result.replace("{{context.execution_dir}}", str(context.execution_dir))
+        result = result.replace("{{context.geometry_dir}}", str(context.workflow_context.parameters["prepared_geometry_dir"]))
+        
         for key, value in context.design_point.items():
             result = result.replace(f"{{design_point.{key}}}", str(value))
         return result

--- a/examples/epic/epic_stack_example.py
+++ b/examples/epic/epic_stack_example.py
@@ -80,7 +80,7 @@ CONST = {
         "epic_environment" : {
             "epic_install" : "epic_example_test/epic",
             "epic_config"  : "epic",
-            "eic_shell"    : "/home/dereka/.bin/eic-shell",
+            "eic_shell"    : "/path/to/my/eic-shell",
         },
     },
 }

--- a/src/aid2e/utilities/configurations/workflow_config.py
+++ b/src/aid2e/utilities/configurations/workflow_config.py
@@ -266,7 +266,8 @@ class WorkflowDefinition(BaseModel):
         default=None,
         description="Workflow-level scheduler default (overrides global, used if branch/stage unset)",
     )
-    
+    stack_type: Optional[str] = Field(default=None,description="Experimental stack type for workflow-level geometry prep")
+
     def get_implicit_branch(self) -> BranchDefinition:
         """Get or create single implicit branch if branches list is empty.
         

--- a/src/aid2e/utilities/epic_utils/epic_stack.py
+++ b/src/aid2e/utilities/epic_utils/epic_stack.py
@@ -255,6 +255,7 @@ class EpicStack(ExperimentStack):
 
         commands = [
             self._determine_shebang(script),
+            "set -euo pipefail",
             f"source {trial_geo_dir}/install/bin/thisepic.sh\nexport $DETECTOR_CONFIG={os.environ['EPIC_CONFIG']}",
         ]
         if preparations != None:

--- a/src/aid2e/utilities/epic_utils/epic_stack.py
+++ b/src/aid2e/utilities/epic_utils/epic_stack.py
@@ -256,10 +256,10 @@ class EpicStack(ExperimentStack):
         commands = [
             self._determine_shebang(script),
             "set -euo pipefail",
-            f"source {trial_geo_dir}/install/bin/thisepic.sh\nexport $DETECTOR_CONFIG={os.environ['EPIC_CONFIG']}",
+            f"source {trial_geo_dir}/install/bin/thisepic.sh\nexport DETECTOR_CONFIG={os.environ['EPIC_CONFIG']}",
         ]
         if preparations != None:
-            commands.extend(preparations)
+            commands.append(preparations)
         commands.extend(self._make_commands(configs))
 
         text = "\n\n".join(commands)

--- a/src/aid2e/utilities/epic_utils/epic_stack.py
+++ b/src/aid2e/utilities/epic_utils/epic_stack.py
@@ -187,8 +187,7 @@ class EpicStack(ExperimentStack):
         modify_xml_files(remapped_modifications)
 
         compile_commands = (
-            f"cmake -B {trial_geo_dir}/build -S {trial_geo_dir}\n"
-            f"-DCMAKE_INSTALL_PREFIX={trial_geo_dir}/install\n"
+            f"cmake -B {trial_geo_dir}/build -S {trial_geo_dir} -DCMAKE_INSTALL_PREFIX={trial_geo_dir}/install\n"
             f"cmake --build {trial_geo_dir}/build\n"
             f"cmake --install {trial_geo_dir}/build\n"
         )
@@ -240,23 +239,12 @@ class EpicStack(ExperimentStack):
             if isinstance(value, JobContext):
                 context = value
 
-        # JobContext must be provided to access execution dir
+        # JobContext, WorkflowContext must be provided to access execution, geoemtry dir
         if context is None:
             raise RuntimeError("No JobContext provided to EpicStack.make_driver_script")
-
-        commands = self._make_commands(configs)
-        commands.insert(0, self._determine_shebang(script))
-        if preparations != None:
-            commands.insert(1, preparations)
-
-        # reconstruct geometry dir for job
-        #   - FIXME this can be improved! We can likely make use
-        #     of xcom to retrieve this
-
-        # template_geo_dir = os.environ['EPIC_INSTALL']
-        # trial_geo_dir = '/'.join([context.execution_dir, os.path.basename(template_geo_dir)])
         if context.workflow_context is None:
             raise RuntimeError("No workflow context provided to EpicStack.make_driver_script")
+
         trial_geo_dir = context.workflow_context.parameters.get("prepared_geometry_dir")
         if not trial_geo_dir:
             raise RuntimeError("No prepared geometry directory found in workflow context")
@@ -265,10 +253,13 @@ class EpicStack(ExperimentStack):
         if 'EPIC_CONFIG' not in os.environ:
             raise EnvironmentError("Variable 'EPIC_CONFIG' not set. Must define epic_config.")
 
-        # ensure detector path is set
-        detector = f"source {trial_geo_dir}/install/bin/thisepic.sh\n" \
-                   f"export DETECTOR_CONFIG={os.environ['EPIC_CONFIG']}"
-        commands.insert(2, detector)
+        commands = [
+            self._determine_shebang(script),
+            f"source {trial_geo_dir}/install/bin/thisepic.sh\nexport $DETECTOR_CONFIG={os.environ['EPIC_CONFIG']}",
+        ]
+        if preparations != None:
+            commands.extend(preparations)
+        commands.extend(self._make_commands(configs))
 
         text = "\n\n".join(commands)
         with open(script, 'w') as driver:

--- a/src/aid2e/utilities/workflows/__init__.py
+++ b/src/aid2e/utilities/workflows/__init__.py
@@ -31,6 +31,7 @@ from aid2e.utilities.configurations.workflow_config import (
 )
 from .execution_utils import build_objective_call
 from .execution_engine import (
+	WorkflowSharedContext,
 	BranchContext,
 	StageContext,
 	JobContext,
@@ -74,6 +75,7 @@ __all__ = [
 	"topological_sort",
 	"detect_cycles",
 	# ExecutionEngines and Contexts
+	"WorkflowSharedContext",
 	"BranchContext",
 	"StageContext",
 	"JobContext",

--- a/src/aid2e/utilities/workflows/execution_engine.py
+++ b/src/aid2e/utilities/workflows/execution_engine.py
@@ -720,6 +720,7 @@ class StackExecutionEngine(BaseExecutionEngine):
         result = text
         result = result.replace("{{context.job_id}}", str(context.job_id))
         result = result.replace("{{context.execution_dir}}", str(context.execution_dir))
+        result = result.replace("{{context.geometry_dir}}", str(context.workflow_context.parameters["prepared_geometry_dir"]))
         for key, value in context.design_point.items():
             result = result.replace(f"{{design_point.{key}}}", str(value))
         return result

--- a/src/aid2e/utilities/workflows/execution_engine.py
+++ b/src/aid2e/utilities/workflows/execution_engine.py
@@ -217,7 +217,7 @@ class BashExecutionEngine(BaseExecutionEngine):
         env: Environment variables (optional).
         
     Example:
-        >epic/scripts/bic_angular_reso.py>> engine = BashExecutionEngine(
+        >>> engine = BashExecutionEngine(
         ...     job_id='run_sim',
         ...     bash_command='python scripts/simulate.py --input {input_file}',
         ...     env={'PYTHONUNBUFFERED': '1'}
@@ -648,7 +648,6 @@ class StackExecutionEngine(BaseExecutionEngine):
                 shell=True,
                 capture_output=True,
                 text=True,
-                cwd=context.execution_dir
             )
 
             # Log output

--- a/src/aid2e/utilities/workflows/workflow_config.py
+++ b/src/aid2e/utilities/workflows/workflow_config.py
@@ -243,7 +243,6 @@ class WorkflowDefinition(BaseModel):
     """
     name: str = Field(..., description="Workflow name")
     description: Optional[str] = Field(default=None, description="Workflow description")
-    stack_type: Optional[str] = Field(default=None,description="Experimental stack type for workflow-level geometry prep")
     branches: List[BranchDefinition] = Field(default_factory=list, description="Workflow branches (optional)")
     objectives: List[ObjectiveDefinition] = Field(
         default_factory=list,
@@ -257,7 +256,8 @@ class WorkflowDefinition(BaseModel):
         default=None,
         description="Workflow-level scheduler default (overrides global, used if branch/stage unset)",
     )
-    
+    stack_type: Optional[str] = Field(default=None,description="Experimental stack type for workflow-level geometry prep")
+
     def get_implicit_branch(self) -> BranchDefinition:
         """Get or create single implicit branch if branches list is empty.
         


### PR DESCRIPTION
This PR works through the remaining bugs blocking `examples/epic/epic_stack_example.py` from running (mostly) out of the box. Completes #50 , but requires #47 first!

### Changes:
- [x] Added/exposed missing parameters, classes
- [x] Added alias for workflow geometry directory
- [x] Fixed minor typo in geometry compilation
- [x] Set `StackExecutionEngine` to run script in CWD, not execution directory
- [x] Set bash options in driver script to fail loudly